### PR TITLE
bug fix: Zip filter udf is passed invalid path LDEV-3866

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      luceeVersion: light-6.0.0.149-SNAPSHOT
+      luceeVersion: light-6.0.0.152-SNAPSHOT
 
     steps:
     - uses: actions/checkout@v2
@@ -53,3 +53,4 @@ jobs:
         extensions: 37C61C0A-5D7E-4256-8572639BE0CF5838 # esapi required to run lucee test suite with lucee light
       env:
         testLabels: zip
+        testAdditional: ${{ github.workspace }}/tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#332E08",
+        "titleBar.activeBackground": "#48410B",
+        "titleBar.activeForeground": "#FCFBEF"
+    }
+}

--- a/source/java/src/org/lucee/extension/zip/filter/UDFFilter.java
+++ b/source/java/src/org/lucee/extension/zip/filter/UDFFilter.java
@@ -45,7 +45,7 @@ public class UDFFilter extends UDFFilterSupport implements ResourceAndResourceNa
 
 	@Override
 	public boolean accept(Resource file) {
-		return accept(file.getAbsolutePath());
+		return accept(file.getPath());
 	}
 
 	@Override

--- a/source/java/src/org/lucee/extension/zip/tag/Zip.java
+++ b/source/java/src/org/lucee/extension/zip/tag/Zip.java
@@ -43,6 +43,7 @@ import org.lucee.extension.zip.filter.WildcardPatternFilter;
 import org.lucee.extension.zip.util.CompressUtil;
 
 import lucee.commons.io.res.Resource;
+import lucee.commons.io.res.ResourceProvider;
 import lucee.commons.io.res.filter.ResourceFilter;
 import lucee.loader.util.Util;
 import lucee.runtime.exp.PageException;
@@ -403,6 +404,7 @@ public final class Zip extends BodyTagImpl {
 
 		ZipFile zip = getZip(file, password);
 		Iterator<FileHeader> it = zip.getFileHeaders().iterator();
+		ResourceProvider frp = engine.getResourceUtil().getFileResourceProvider();
 
 		try {
 			FileHeader fh;
@@ -420,7 +422,7 @@ public final class Zip extends BodyTagImpl {
 				dir = index == -1 ? "" : path.substring(0, index);
 				name = path.substring(index + 1);
 
-				if (filter != null && !filter.accept(file.getRealResource(name))) continue;
+				if (filter != null && !filter.accept(frp.getResource(path))) continue;
 
 				if (!entryPathMatch(dir)) continue;
 				// if(entryPath!=null && !(dir.equalsIgnoreCase(entryPath) ||

--- a/tests/ZipFilterUdf.cfc
+++ b/tests/ZipFilterUdf.cfc
@@ -1,0 +1,86 @@
+<!--- 
+ *
+ * Copyright (c) 2016, Lucee Assosication Switzerland. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either 
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ ---><cfscript>
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="zip" {
+
+	public function setUp() {
+		
+		variables.currFile = getCurrentTemplatePath();
+		variables.currDir = getDirectoryFromPath( currFile );
+		variables.testSubFolder = "zipUDFtest";
+		variables.root = currDir & "#variables.testSubFolder#/";
+
+		variables.dir = root & "a/b/c/";
+		variables.file1 = dir & "a.txt"
+		variables.dir1 = root & "a/";
+		variables.file2 = root & "a/b.txt";
+		variables.target = root & "test.zip";
+		
+		if ( directoryExists( root ) ) directoryDelete( root, true );
+
+		directoryCreate( dir );
+		fileWrite( file1, "file 1" );
+		fileWrite( file2, "file 2" );
+	}
+
+	// ensure the paths passed to the filter UDF are relative
+	public function testZipFilterUdfPaths() {
+		try {
+			if ( fileExists( target ) ) fileDelete( target );
+			// zip
+			zip action="zip" file=target {
+				zipparam entryPath = "/1/2.cfm" source=variables.file1;
+				zipparam source = variables.file1;
+				zipparam source = variables.dir1;
+				zipparam prefix="n/m" source =variables.dir1;
+			}
+
+			// first test normal filter wildcards
+			zip action="list" file=target name="local.qry" filter="*.zip"; 
+			expect( qry.recordcount ).toBe( 0 ); // there are no zips
+			
+			zip action="list" file=target name="local.qry" filter="#variables.testSubFolder#/*";
+			expect( qry.recordcount ).toBe( 0 ); // shouldn't match parent folder
+
+			zip action="list" file=target name="local.qry" filter="*.txt";
+			expect( qry.recordcount ).toBe( 5 );
+
+			zip action="list" file=target name="local.qry" filter="*.cfm";
+			expect( qry.recordcount ).toBe( 1 );
+			
+			// then test udf filters
+			var zipEntryPaths = [];
+			var zipListFilter = function ( zipEntryPath ) {
+				ArrayAppend( zipEntryPaths, replace( zipEntryPath, "\", "/", "all" ) );
+				return true;
+			};
+
+			// list
+			zip action="list" file=target name="local.qry" filter=zipListFilter;
+
+			expect( qry.recordcount ).toBe( 6 );
+			expect( listSort( ArrayToList( zipEntryPaths ), 'textnocase' ) ).toBe( '1/2.cfm,a.txt,b.txt,b/c/a.txt,n/m/b.txt,n/m/b/c/a.txt' );
+
+
+		}
+		finally {
+			if ( directoryExists(root) ) directoryDelete( root, true );
+		}
+	}
+} 
+</cfscript>


### PR DESCRIPTION
so far, this just passes in the full invalid path (adds in the missing zip entry path)

<img width="356" alt="image" src="https://user-images.githubusercontent.com/426404/152690186-271d409d-7555-48e1-b4e0-3d7f0caeda58.png">

which is better than 
<img width="297" alt="image" src="https://user-images.githubusercontent.com/426404/152691119-6f1bb728-3102-402d-b2a5-a0c18928b490.png">


https://luceeserver.atlassian.net/browse/LDEV-3866